### PR TITLE
Implement efficient map iter, fix test bug

### DIFF
--- a/gomaps/gomaps.go
+++ b/gomaps/gomaps.go
@@ -1,18 +1,22 @@
 package gomaps
 
 import (
+	"reflect"
+
 	"github.com/shayanh/gcl"
 	"github.com/shayanh/gcl/iters"
 )
 
 func Iter[M ~map[K]V, K comparable, V any](m M) *Iterator[K, V] {
+	impl := reflect.ValueOf(m).MapRange()
 	return &Iterator[K, V]{
-		m:     m,
-		index: -1,
+		impl:    impl,
+		hasNext: impl.Next(),
 	}
 }
 
-func FromIter[K comparable, V any](it iters.Iterator[gcl.MapElem[K, V]]) (res map[K]V) {
+func FromIter[K comparable, V any, IT iters.Iterator[gcl.MapElem[K, V]]](it IT) (res map[K]V) {
+	res = make(map[K]V)
 	for it.HasNext() {
 		elem := it.Next()
 		res[elem.Key] = elem.Value

--- a/gomaps/iter.go
+++ b/gomaps/iter.go
@@ -1,31 +1,26 @@
 package gomaps
 
 import (
+	"reflect"
+
 	"github.com/shayanh/gcl"
-	"golang.org/x/exp/maps"
 )
 
 type Iterator[K comparable, V any] struct {
-	m     map[K]V
-	keys  []K
-	index int
+	impl    *reflect.MapIter
+	hasNext bool
 }
 
 func (it *Iterator[K, V]) HasNext() bool {
-	if it.keys == nil {
-		return len(it.m) > 0
-	}
-	return it.index+1 < len(it.keys)
+	return it.hasNext
 }
 
 func (it *Iterator[K, V]) Next() gcl.MapElem[K, V] {
-	if it.keys == nil {
-		it.keys = maps.Keys(it.m)
-	}
-	it.index += 1
-	key := it.keys[it.index]
+	key := it.impl.Key().Interface().(K)
+	value := it.impl.Value().Interface().(V)
+	it.hasNext = it.impl.Next()
 	return gcl.MapElem[K, V]{
 		Key:   key,
-		Value: it.m[key],
+		Value: value,
 	}
 }

--- a/iters/ops_test.go
+++ b/iters/ops_test.go
@@ -10,34 +10,34 @@ import (
 )
 
 var equalTests = []struct {
-	it1, it2 iters.Iterator[int]
+	it1, it2 func() iters.Iterator[int]
 	want     bool
 }{
 	{
-		goslices.Iter[[]int](nil),
-		goslices.Iter[[]int](nil),
+		func() iters.Iterator[int] { return goslices.Iter[[]int](nil) },
+		func() iters.Iterator[int] { return goslices.Iter[[]int](nil) },
 		true,
 	},
 	{
-		goslices.Iter([]int{1, 2, 3}),
-		goslices.Iter([]int{1, 2, 3}),
+		func() iters.Iterator[int] { return goslices.Iter([]int{1, 2, 3}) },
+		func() iters.Iterator[int] { return goslices.Iter([]int{1, 2, 3}) },
 		true,
 	},
 	{
-		goslices.Iter([]int{1, 1, 1}),
-		goslices.Iter([]int{1, 2, 1}),
+		func() iters.Iterator[int] { return goslices.Iter([]int{1, 1, 1}) },
+		func() iters.Iterator[int] { return goslices.Iter([]int{1, 2, 1}) },
 		false,
 	},
 	{
-		goslices.Iter([]int{1, 2, 3}),
-		goslices.Iter([]int{1, 2, 3, 4}),
+		func() iters.Iterator[int] { return goslices.Iter([]int{1, 2, 3}) },
+		func() iters.Iterator[int] { return goslices.Iter([]int{1, 2, 3, 4}) },
 		false,
 	},
 }
 
 func TestEqual(t *testing.T) {
 	for _, test := range equalTests {
-		if res := iters.Equal(test.it1, test.it2); res != test.want {
+		if res := iters.Equal(test.it1(), test.it2()); res != test.want {
 			t.Errorf("Equal(it1, it2) = %v, want = %v", res, test.want)
 		}
 	}
@@ -45,7 +45,7 @@ func TestEqual(t *testing.T) {
 
 func TestEqualFunc(t *testing.T) {
 	for _, test := range equalTests {
-		if res := iters.EqualFunc(test.it1, test.it2, gcl.Equal[int]); res != test.want {
+		if res := iters.EqualFunc(test.it1(), test.it2(), gcl.Equal[int]); res != test.want {
 			t.Errorf("Equal(it1, it2) = %v, want = %v", res, test.want)
 		}
 	}


### PR DESCRIPTION
Map iteration now uses the reflect package to avoid the alternatives of allocating potentially large slices of keys or strange goroutine trickery which we discussed IRL.

There were iterator tests already, so I kept them as-is.

I did notice a strange test failure due to iterator objects getting re-used across two separate tests, so I fixed that by thunking iterator instantiation, wrapping the iterator construction in parameterless functions.